### PR TITLE
Use dark.min.css with DarkBetter theme

### DIFF
--- a/init.js
+++ b/init.js
@@ -91,7 +91,10 @@ function()
 {
 	var this_ = this;
 
-	this.loadCSS("css/" + this.getThemeName() + ".min");
+	if (this.getThemeName() === "darkbetter")
+		this.loadCSS("css/dark.min");
+	else
+		this.loadCSS("css/" + this.getThemeName() + ".min");
 
 	// Note: These files aren't necessarily loaded in order! They must not rely on other JS files.
 	this.loadJavaScriptFiles(


### PR DESCRIPTION
This plugin is missing a css file for ruTorrent's stock DarkBetter theme, as a result the log tab and configuration windows are poorly styled. This minor change reuses the css file from the Dark theme which works well for me.