### PR TITLE
Resolve syntax errors

### DIFF
--- a/js/Filters.js
+++ b/js/Filters.js
@@ -474,7 +474,7 @@ function(multiSelectDlgBox, okHandler)
 							'<tr>' +
 								'<td>' +
 									'<label for="autodl-filters-scene">' + theUILang.autodlScene + '</label>' +
-									'<select id="autodl-filters-scene"></input>' +
+									'<select id="autodl-filters-scene"></select>' +
 									'<label for="autodl-filters-origins">' + theUILang.autodlOrigins + '</label>' +
 									'<input type="text" class="textbox-16" id="autodl-filters-origins" title="' + theUILang.autodlTitle60 + '"placeholder="' + theUILang.autodlHint35 + '"></input>' +
 								'</td>' +

--- a/js/Trackers.js
+++ b/js/Trackers.js
@@ -243,7 +243,7 @@ function(trackerInfo)
 			if (tbody == null)
 			{
 				tbody = $('<tbody></tbody>');
-				div.append($('<br></br><table></tabel>').append(tbody));
+				div.append($('<br></br><table></table>').append(tbody));
 			}
 			tbody.append(elem);
 		}


### PR DESCRIPTION
Fixes a regression with ruTorrent v4.0 syntax changes in 736aeca560a00b120062bc51d790779ecdec6332.
